### PR TITLE
correct postgresql secret name in _helpers.tpl

### DIFF
--- a/waldur/templates/_helpers.tpl
+++ b/waldur/templates/_helpers.tpl
@@ -56,7 +56,7 @@ Set postgres host
 */}}
 {{- define "waldur.postgresql.host" -}}
 {{- if .Values.postgresql.HAEnabed -}}
-"postgresql-ha-waldur-pgpool"
+"	waldur-postgresql-ha-pgpool"
 {{- else -}}
 "postgresql-waldur"
 {{- end -}}
@@ -74,9 +74,9 @@ Set postgres secret
 */}}
 {{- define "waldur.postgresql.secret" -}}
 {{- if .Values.postgresql.HAEnabed -}}
-"postgresql-ha-waldur-postgresql"
+"waldur-postgresql-ha-postgresql"
 {{- else -}}
-"postgresql-waldur"
+"waldur-postgresql"
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
When deploying the helm chart, the secret "postgresql-ha-waldur-postgresql" can not be found. This is because the secret is stored under the name "waldur-postgresql-ha-postgresql". The same is with non-ha version as well as pool version. 
Proposed change corrects the naming convention to the same used as secret currently.