### PR TITLE
feat: add externaldb passwordKey

### DIFF
--- a/docs/external-db-integration.md
+++ b/docs/external-db-integration.md
@@ -8,8 +8,7 @@ For this, you need to set the following variables in `values.yaml`:
 2. `externalDB.flavor` - a type of the DB management system; currently only `zalando` ([Zalando operator](https://postgres-operator.readthedocs.io/en/latest/)) is supported
 3. `externalDB.secretName` - name of the secret with PostgreSQL credentials for Waldur user; should include `username` and `password` keys
 4. `externalDB.serviceName` - name of the service linked to PostgreSQL master
-5. `externalDB.usernameKey` - name of the key defining the PostgreSQL user's name; default: `username`
-6. `externalDB.passwordKey` - name of the key defining the PostgreSQL user's password; default: `password`
+5. `externalDB.passwordKey` - name of the key defining the PostgreSQL user's password; default: `password`
 
 Zalando-managed PostgreSQL cluster example:
 

--- a/docs/external-db-integration.md
+++ b/docs/external-db-integration.md
@@ -8,6 +8,8 @@ For this, you need to set the following variables in `values.yaml`:
 2. `externalDB.flavor` - a type of the DB management system; currently only `zalando` ([Zalando operator](https://postgres-operator.readthedocs.io/en/latest/)) is supported
 3. `externalDB.secretName` - name of the secret with PostgreSQL credentials for Waldur user; should include `username` and `password` keys
 4. `externalDB.serviceName` - name of the service linked to PostgreSQL master
+5. `externalDB.usernameKey` - name of the key defining the PostgreSQL user's name; default: `username`
+6. `externalDB.passwordKey` - name of the key defining the PostgreSQL user's password; default: `password`
 
 Zalando-managed PostgreSQL cluster example:
 

--- a/waldur/templates/_helpers.tpl
+++ b/waldur/templates/_helpers.tpl
@@ -179,11 +179,11 @@ Add environment variables to configure database values and Sentry environment
   value: {{ include "waldur.postgresql.port" . }}
 
 - name: POSTGRESQL_USER
-{{ if .Values.externalDB.enabled (eq .Values.externalDB.flavor "zalando") }}
+{{ if and .Values.externalDB.enabled (eq .Values.externalDB.flavor "zalando") }}
   valueFrom:
     secretKeyRef:
       name: {{ include "waldur.postgresql.secret" . }}
-      key: {{ include "waldur.postgresql.secret.usernameKey" . }}
+      key: username
 {{ else }}
   value: {{ include "waldur.postgresql.user" . }}
 {{ end }}

--- a/waldur/templates/_helpers.tpl
+++ b/waldur/templates/_helpers.tpl
@@ -91,8 +91,23 @@ Set postgres secret
 {{/*
 Set postgres secret password key
 */}}
+{{- define "waldur.postgresql.secret.usernameKey" -}}
+{{- if .Values.externalDB.enabled -}}
+{{ .Values.externalDB.usernameKey }}
+{{- else -}}
+"username"
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set postgres secret password key
+*/}}
 {{- define "waldur.postgresql.secret.passwordKey" -}}
+{{- if .Values.externalDB.enabled -}}
+{{ .Values.externalDB.passwordKey }}
+{{- else -}}
 "password"
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -179,7 +194,7 @@ Add environment variables to configure database values and Sentry environment
   valueFrom:
     secretKeyRef:
       name: {{ include "waldur.postgresql.secret" . }}
-      key: username
+      key: {{ include "waldur.postgresql.secret.usernameKey" . }}
 {{ else }}
   value: {{ include "waldur.postgresql.user" . }}
 {{ end }}

--- a/waldur/templates/_helpers.tpl
+++ b/waldur/templates/_helpers.tpl
@@ -91,17 +91,6 @@ Set postgres secret
 {{/*
 Set postgres secret password key
 */}}
-{{- define "waldur.postgresql.secret.usernameKey" -}}
-{{- if .Values.externalDB.enabled -}}
-{{ .Values.externalDB.usernameKey }}
-{{- else -}}
-"username"
-{{- end -}}
-{{- end -}}
-
-{{/*
-Set postgres secret password key
-*/}}
 {{- define "waldur.postgresql.secret.passwordKey" -}}
 {{- if .Values.externalDB.enabled -}}
 {{ .Values.externalDB.passwordKey }}
@@ -190,7 +179,7 @@ Add environment variables to configure database values and Sentry environment
   value: {{ include "waldur.postgresql.port" . }}
 
 - name: POSTGRESQL_USER
-{{ if and .Values.externalDB.enabled (eq .Values.externalDB.flavor "zalando") }}
+{{ if .Values.externalDB.enabled (eq .Values.externalDB.flavor "zalando") }}
   valueFrom:
     secretKeyRef:
       name: {{ include "waldur.postgresql.secret" . }}

--- a/waldur/test/values.yaml
+++ b/waldur/test/values.yaml
@@ -479,8 +479,7 @@ externalDB:
   flavor: "zalando"
   secretName: "waldur.waldur-testing-postgres.credentials.postgresql.acid.zalan.do"
   serviceName: "waldur-testing-postgres"
-  passwordKey: password
-  usernameKey: username
+  passwordKey: "password"
 
 postgresql:
   enabled: true

--- a/waldur/test/values.yaml
+++ b/waldur/test/values.yaml
@@ -479,6 +479,8 @@ externalDB:
   flavor: "zalando"
   secretName: "waldur.waldur-testing-postgres.credentials.postgresql.acid.zalan.do"
   serviceName: "waldur-testing-postgres"
+  passwordKey: password
+  usernameKey: username
 
 postgresql:
   enabled: true

--- a/waldur/values.yaml
+++ b/waldur/values.yaml
@@ -443,6 +443,8 @@ externalDB:
   flavor: "zalando"
   secretName: "waldur.waldur.credentials.postgresql.acid.zalan.do"
   serviceName: "waldur-postgres"
+  usernameKey: "username"
+  passwordKey: "password"
 
 postgresql:
   enabled: false

--- a/waldur/values.yaml
+++ b/waldur/values.yaml
@@ -443,7 +443,6 @@ externalDB:
   flavor: "zalando"
   secretName: "waldur.waldur.credentials.postgresql.acid.zalan.do"
   serviceName: "waldur-postgres"
-  usernameKey: "username"
   passwordKey: "password"
 
 postgresql:


### PR DESCRIPTION
Allow overriding the `externalDB` password keys.

```yaml
externalDB:
  enabled: false
  flavor: "zalando"
  secretName: "waldur.waldur.credentials.postgresql.acid.zalan.do"
  serviceName: "waldur-postgres"
  passwordKey: "password"
```