### PR TITLE
feat: marketplace jobs default namespace

### DIFF
--- a/docs/marketplace-script.md
+++ b/docs/marketplace-script.md
@@ -5,7 +5,7 @@ Available options in `values.yaml`:
 - `waldur.marketplace.script.enabled` - enable/disable plugin
 - `waldur.marketplace.script.dockerImages` - key-value structure, where key is a programming language
   and value - a corresponding docker image tag
-- `waldur.marketplace.script.k8sNamespace` - Kubernetes namespace, where jobs will be executed
+- `waldur.marketplace.script.k8sNamespace` - Kubernetes namespace, where jobs will be executed; default: `default`
 - `waldur.marketplace.script.kubeconfigPath` - path to local file with kubeconfig content
 - `waldur.marketplace.script.kubeconfig` - kubeconfig file content takes precedence over `.kubeconfigPath` option
 - `waldur.marketplace.script.jobTimeout` - timeout for Kubernetes jobs

--- a/waldur/templates/config-marketplace-script.yaml
+++ b/waldur/templates/config-marketplace-script.yaml
@@ -15,7 +15,7 @@ data:
     K8S_CONFIG_PATH: /etc/waldur/kubeconfig
 
     # Namespace where jobs will be created
-    K8S_NAMESPACE: "{{ .Values.waldur.marketplace.script.k8sNamespace }}"
+    K8S_NAMESPACE: "{{ .Values.waldur.marketplace.script.k8sNamespace | default .Release.Namespace }}"
 
     {{ if .Values.waldur.marketplace.script.dockerImages }}
     # Available Docker images for script execution


### PR DESCRIPTION
Use the `.Release.namespace` as the default for the marketplace jobs:

```yaml
waldur:
  marketplace:
    script:
      k8sNamespace: "" # will fall back to `.Release.namespace`
```

Optional: you could set `""` as the default instead of using `default` but might be a breaking change for others.