### PR TITLE
feat: only add secretName if configured

### DIFF
--- a/waldur/templates/ingress-api-admin.yaml
+++ b/waldur/templates/ingress-api-admin.yaml
@@ -83,7 +83,7 @@ spec:
     {{ end }}
     {{ if .Values.ingress.tls.customMastermindSecretName }}
     secretName: {{ .Values.ingress.tls.customMastermindSecretName | quote }}
-    {{ else }}
+    {{ else if or (eq .Values.ingress.tls.source "secret") (eq .Values.ingress.tls.source "letsEncrypt") }}
     secretName: api-certificate
     {{ end }}
   {{ end }}

--- a/waldur/templates/ingress-api.yaml
+++ b/waldur/templates/ingress-api.yaml
@@ -98,7 +98,7 @@ spec:
     {{ end }}
     {{ if .Values.ingress.tls.customMastermindSecretName }}
     secretName: {{ .Values.ingress.tls.customMastermindSecretName | quote }}
-    {{ else }}
+    {{ else if or (eq .Values.ingress.tls.source "secret") (eq .Values.ingress.tls.source "letsEncrypt") }}
     secretName: api-certificate
     {{ end }}
   {{ end }}

--- a/waldur/templates/ingress-homeport.yaml
+++ b/waldur/templates/ingress-homeport.yaml
@@ -79,7 +79,7 @@ spec:
     {{ end }}
     {{ if .Values.ingress.tls.customHomeportSecretName }}
     secretName: {{ .Values.ingress.tls.customHomeportSecretName | quote }}
-    {{ else }}
+    {{ else if or (eq .Values.ingress.tls.source "secret") (eq .Values.ingress.tls.source "letsEncrypt") }}
     secretName: homeport-certificate
     {{ end }}
   {{ end }}

--- a/waldur/templates/ingress-rmq-ws.yaml
+++ b/waldur/templates/ingress-rmq-ws.yaml
@@ -43,7 +43,7 @@ spec:
     - {{ .Values.apiHostname }}
     {{ if .Values.ingress.tls.customMastermindSecretName }}
     secretName: {{ .Values.ingress.tls.customMastermindSecretName | quote }}
-    {{ else }}
+    {{ else if or (eq .Values.ingress.tls.source "secret") (eq .Values.ingress.tls.source "letsEncrypt") }}
     secretName: api-certificate
     {{ end }}
   {{ end }}

--- a/waldur/templates/ingress-uvk-everypay.yaml
+++ b/waldur/templates/ingress-uvk-everypay.yaml
@@ -36,5 +36,9 @@ spec:
   tls:
   - hosts:
     - {{ .Values.apiHostname }}
+    {{ if .Values.ingress.tls.customMastermindSecretName }}
+    secretName: {{ .Values.ingress.tls.customMastermindSecretName | quote }}
+    {{ else if or (eq .Values.ingress.tls.source "secret") (eq .Values.ingress.tls.source "letsEncrypt") }}
     secretName: api-certificate
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
In some cases (e.g. when using the default secret by you're ingress) you don't want to define a `secretName`.

```yaml
ingress:
  tls:
    source: ""
```